### PR TITLE
Add secure API key storage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
 
     // Jetpack Compose (与 kotlin 1.9.22 兼容)
     implementation("androidx.compose.ui:ui:1.8.3")
-    implementation(libs.material3)
+    implementation("androidx.compose.material3:material3:1.2.1")
     implementation("androidx.compose.material:material:1.8.3")
     implementation("androidx.compose.material:material-icons-extended:1.7.8")
     debugImplementation("androidx.compose.ui:ui-tooling:1.8.3")
@@ -94,6 +94,9 @@ dependencies {
 
     // DataStore
     implementation("androidx.datastore:datastore-preferences:1.0.0")
+
+    // Jetpack Security for encrypted storage
+    implementation("androidx.security:security-crypto:1.1.0-alpha06")
 
     // Coroutines – 使用 Kotlin 1.9.x 对应版本
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")

--- a/app/src/main/java/com/example/cryptotrader/TradingApplication.kt
+++ b/app/src/main/java/com/example/cryptotrader/TradingApplication.kt
@@ -3,6 +3,7 @@ package com.example.cryptotrader
 import android.app.Application
 import com.example.cryptotrader.data.FavoritesRepository
 import com.example.cryptotrader.data.TickerRepository
+import com.example.cryptotrader.data.local.ApiKeyStorage
 import dagger.hilt.android.HiltAndroidApp
 
 /**
@@ -14,5 +15,8 @@ class TradingApplication : Application() {
         super.onCreate()
         FavoritesRepository.init(this)
         TickerRepository.startMock()            // 启动行情流// 初始化 Room
+        // Initialize secure storage and save demo credentials
+        ApiKeyStorage.init(this)
+        ApiKeyStorage.saveCredentials("demo_key", "demo_secret")
     }
 }

--- a/app/src/main/java/com/example/cryptotrader/data/local/ApiKeyStorage.kt
+++ b/app/src/main/java/com/example/cryptotrader/data/local/ApiKeyStorage.kt
@@ -1,0 +1,50 @@
+package com.example.cryptotrader.data.local
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+/**
+ * Simple helper for storing API credentials securely using
+ * [EncryptedSharedPreferences] backed by the Android Keystore.
+ */
+object ApiKeyStorage {
+
+    private const val PREFS_FILE = "secure_api_prefs"
+    private const val KEY_API_KEY = "api_key"
+    private const val KEY_API_SECRET = "api_secret"
+
+    private lateinit var prefs: SharedPreferences
+
+    /**
+     * Initializes the encrypted preferences. Should be called once, e.g. in
+     * [android.app.Application.onCreate].
+     */
+    fun init(context: Context) {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+
+        prefs = EncryptedSharedPreferences.create(
+            context,
+            PREFS_FILE,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+
+    /** Stores the given key and secret. */
+    fun saveCredentials(apiKey: String, apiSecret: String) {
+        prefs.edit()
+            .putString(KEY_API_KEY, apiKey)
+            .putString(KEY_API_SECRET, apiSecret)
+            .apply()
+    }
+
+    fun getApiKey(): String? = prefs.getString(KEY_API_KEY, null)
+
+    fun getApiSecret(): String? = prefs.getString(KEY_API_SECRET, null)
+}
+


### PR DESCRIPTION
## Summary
- add `ApiKeyStorage` using EncryptedSharedPreferences
- save demo credentials at app startup
- include security-crypto dependency and fix material3 version

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f56029ed08321a32954f72f10a30f